### PR TITLE
Add trim

### DIFF
--- a/plugin/license.vim
+++ b/plugin/license.vim
@@ -31,8 +31,8 @@ function! InsertLicense(lic, stub)
     if l:which > -1
         execute '0read ' . l:files[l:which]
         execute "'[,']" . 's/{YEAR}/\=strftime("%Y")/e'
-        execute "'[,']s/{AUTHOR}/" . get(g:, 'license_author', executable('git') ? system('git config --global user.name') : expand('$USER')) . '/e'
-        execute "'[,']s/{EMAIL}/" .  get(g:, 'license_email', executable('git') ? system('git config --global user.email') : expand('$HOST')) . '/e'
+        execute "'[,']s/{AUTHOR}/" . get(g:, 'license_author', executable('git') ? trim(system('git config --global user.name')) : expand('$USER')) . '/e'
+        execute "'[,']s/{EMAIL}/" .  get(g:, 'license_email', executable('git') ? trim(system('git config --global user.email')) : expand('$HOST')) . '/e'
     else
         echoerr 'No matching ' . l:type . ' found for `' . a:lic . '`'
     endif


### PR DESCRIPTION
sorry for my disturbance!
i read <https://github.com/honza/vim-snippets/blob/d4c285e8e7b482db810f453a308d45f259facbf9/plugin/vimsnippets.vim#L14>, and find <https://github.com/ararslan/license-to-vim/blob/e76b6714c7b9339751a85c3f77026dd93bcb131c/plugin/license.vim#L34> exists some bug.

```{.vim}
echo system('git config --global user.name')
```

will return
![image](https://user-images.githubusercontent.com/32936898/94022301-89d60a00-fde7-11ea-8be6-a061174f17fe.png)

there exists a "\n" in the last character of the string.

`trim()` will remove the invisiable character of the string.

```{.vim}
echo trim(system('git config --global user.name'))
```

![image](https://user-images.githubusercontent.com/32936898/94024764-5ea0ea00-fdea-11ea-91a1-1b0f4ab51fb3.png)

Thanks!