### PR TITLE
`git config --get` should not use `--system`

### DIFF
--- a/plugin/license.vim
+++ b/plugin/license.vim
@@ -31,8 +31,8 @@ function! InsertLicense(lic, stub)
     if l:which > -1
         execute '0read ' . l:files[l:which]
         execute "'[,']" . 's/{YEAR}/\=strftime("%Y")/e'
-        execute "'[,']s/{AUTHOR}/" . get(g:, 'license_author', executable('git') ? trim(system('git config --global user.name')) : expand('$USER')) . '/e'
-        execute "'[,']s/{EMAIL}/" .  get(g:, 'license_email', executable('git') ? trim(system('git config --global user.email')) : expand('$HOST')) . '/e'
+        execute "'[,']s/{AUTHOR}/" . get(g:, 'license_author', executable('git') ? trim(system('git config --get user.name')) : expand('$USER')) . '/e'
+        execute "'[,']s/{EMAIL}/" .  get(g:, 'license_email', executable('git') ? trim(system('git config --get user.email')) : expand('$HOST')) . '/e'
     else
         echoerr 'No matching ' . l:type . ' found for `' . a:lic . '`'
     endif


### PR DESCRIPTION
Local git repo config should take precedence which `--system` disables. See the manpage git-config(1) section "FILES" for details.